### PR TITLE
Fixed Infinite Update Loop Issue

### DIFF
--- a/src/providers/umiProvider.tsx
+++ b/src/providers/umiProvider.tsx
@@ -5,7 +5,7 @@ import useUmiStore from "@/store/useUmiStore";
 import { WalletAdapter } from "@solana/wallet-adapter-base";
 import { useWallet } from "@solana/wallet-adapter-react";
 
-import { createContext, useContext, useEffect } from "react";
+import React, { createContext, useContext, useEffect } from "react";
 
 // interface context {
 //   // umi: Umi;
@@ -17,7 +17,7 @@ import { createContext, useContext, useEffect } from "react";
 
 // const UmiContext = createContext<context>(defaultContext);
 
-function UmiProvider({ children }: { children: any }) {
+function UmiProvider({ children }: { children: React.ReactNode }) {
   const wallet = useWallet();
   const umiStore = useUmiStore();
 
@@ -25,7 +25,7 @@ function UmiProvider({ children }: { children: any }) {
     if (!wallet.publicKey) return;
     // When wallet.publicKey changes, update the signer in umiStore with the new wallet adapter.
     umiStore.updateSigner(wallet as unknown as WalletAdapter);
-  }, [wallet.publicKey]);
+  }, [wallet, umiStore]);
 
   return <>{children}</>;
 }

--- a/src/store/useUmiStore.ts
+++ b/src/store/useUmiStore.ts
@@ -17,7 +17,7 @@ interface UmiState {
   updateSigner: (signer: WalletAdapter) => void;
 }
 
-const useUmiStore = create<UmiState>()((set) => ({
+const useUmiStore = create<UmiState>()((set, get) => ({
   umi: createUmi("http://api.devnet.solana.com").use(
     signerIdentity(
       createNoopSigner(publicKey("11111111111111111111111111111111"))
@@ -25,7 +25,15 @@ const useUmiStore = create<UmiState>()((set) => ({
   ),
   signer: undefined,
   updateSigner: (signer) => {
-    set(() => ({ signer: createSignerFromWalletAdapter(signer) }));
+    const currentSigner = get().signer;
+    const newSigner = createSignerFromWalletAdapter(signer);
+
+    if (
+      !currentSigner ||
+      currentSigner.publicKey.toString() !== newSigner.publicKey.toString()
+    ) {
+      set(() => ({ signer: newSigner }));
+    }
   },
 }));
 


### PR DESCRIPTION
Added a comparison logic in the updateSigner method of zustand to ensure that the state is only updated when the signer actually changes.
Prevented repeated state updates caused by useEffect, avoiding the error of maximum update depth exceeded.