### PR TITLE
Update the signer and reinitialize the Umi instance

### DIFF
--- a/src/store/useUmiStore.ts
+++ b/src/store/useUmiStore.ts
@@ -27,12 +27,13 @@ const useUmiStore = create<UmiState>()((set, get) => ({
   updateSigner: (signer) => {
     const currentSigner = get().signer;
     const newSigner = createSignerFromWalletAdapter(signer);
+    const newUmi = get().umi.use(signerIdentity(newSigner));
 
     if (
       !currentSigner ||
       currentSigner.publicKey.toString() !== newSigner.publicKey.toString()
     ) {
-      set(() => ({ signer: newSigner }));
+      set(() => ({ signer: newSigner, umi: newUmi }));
     }
   },
 }));


### PR DESCRIPTION
When the signer changes, Update the Umi instance and bind it to the new signer identity. This ensures the Umi instance stays synchronized with the current signer, avoiding transaction failures due to mismatched signer identities.